### PR TITLE
Use static Open Graph metadata from frontmatter

### DIFF
--- a/src/content/config.js
+++ b/src/content/config.js
@@ -6,6 +6,7 @@ const postCollection = defineCollection({
     title: z.string(),
     description: z.string(),
     dateFormatted: z.string(),
+    image: z.string().optional(),
   }),
 })
 

--- a/src/content/post/new-blog-with-nextra.md
+++ b/src/content/post/new-blog-with-nextra.md
@@ -3,7 +3,7 @@ title: 'Next.js / Nextra 重构博客'
 dateFormatted: 2022/11/04
 description: '折腾永无止境，但如何面对过去和未来。删了一些博文，也会增加新的。'
 author: Aozaki
-image:
+image: https://img.aozaki.cc/20210820/0001.png
 ---
 
 ## 重构？

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -12,7 +12,7 @@ const metaDescription = description ?? DEFAULT_DESCRIPTION
 const metaImage = image ?? DEFAULT_IMAGE
 const isArticle = Boolean(description || image)
 
-import '..//styles/global.css'
+import '../styles/global.css'
 ---
 
 <!doctype html>

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -5,7 +5,7 @@ import SquareLines from '../components/square-lines.astro'
 
 const DEFAULT_DESCRIPTION =
   "Aozaki的个人博客，偶尔写点东西。 / Aozaki's blog, writing to record my life and hobbies."
-const DEFAULT_IMAGE = 'https://img.aozaki.cc/20250622/cover.jpg'
+const DEFAULT_IMAGE = 'https://img.aozaki.cc/twitter-card.jpg'
 
 const { title, description, image } = Astro.props
 const metaDescription = description ?? DEFAULT_DESCRIPTION

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -2,7 +2,7 @@
 import Footer from '../components/footer.astro'
 import Header from '../components/header.astro'
 import SquareLines from '../components/square-lines.astro'
-const { title } = Astro.props
+const { title, description, image } = Astro.props
 
 import '..//styles/global.css'
 ---
@@ -13,6 +13,13 @@ import '..//styles/global.css'
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    {title && <meta property="og:title" content={title} />}
+    {description && <meta property="og:description" content={description} />}
+    {image && <meta property="og:image" content={image} />}
+    {(description || image) && (
+      <meta property="og:type" content="article" />
+    )}
 
     <!-- Used to add dark mode right away, adding here prevents any flicker -->
     <script is:inline>

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -2,7 +2,15 @@
 import Footer from '../components/footer.astro'
 import Header from '../components/header.astro'
 import SquareLines from '../components/square-lines.astro'
+
+const DEFAULT_DESCRIPTION =
+  "Aozaki的个人博客，偶尔写点东西。 / Aozaki's blog, writing to record my life and hobbies."
+const DEFAULT_IMAGE = 'https://img.aozaki.cc/20250622/cover.jpg'
+
 const { title, description, image } = Astro.props
+const metaDescription = description ?? DEFAULT_DESCRIPTION
+const metaImage = image ?? DEFAULT_IMAGE
+const isArticle = Boolean(description || image)
 
 import '..//styles/global.css'
 ---
@@ -13,11 +21,13 @@ import '..//styles/global.css'
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
-    {description && <meta name="description" content={description} />}
+    {metaDescription && <meta name="description" content={metaDescription} />}
     {title && <meta property="og:title" content={title} />}
-    {description && <meta property="og:description" content={description} />}
-    {image && <meta property="og:image" content={image} />}
-    {(description || image) && (
+    {metaDescription && (
+      <meta property="og:description" content={metaDescription} />
+    )}
+    {metaImage && <meta property="og:image" content={metaImage} />}
+    {isArticle && (
       <meta property="og:type" content="article" />
     )}
 

--- a/src/layouts/post.astro
+++ b/src/layouts/post.astro
@@ -18,7 +18,11 @@ function formatDate(dateStr) {
 const postDate = formatDate(frontmatter.dateFormatted)
 ---
 
-<Layout title={frontmatter.title}>
+<Layout
+  title={frontmatter.title}
+  description={frontmatter.description}
+  image={frontmatter.image}
+>
   <main
     class="relative z-30 max-w-4xl pb-1 mx-auto mt-10 bg-white dark:bg-neutral-900 md:rounded-t-md text-neutral-900"
   >

--- a/src/pages/post/[slug].astro
+++ b/src/pages/post/[slug].astro
@@ -18,9 +18,9 @@ const { entry } = Astro.props
 const { Content } = await entry.render()
 
 // ➍ 取 front-matter
-const { title, description, dateFormatted } = entry.data
+const { title, description, dateFormatted, image } = entry.data
 ---
 
-<PostLayout frontmatter={{ title, description, dateFormatted }}>
+<PostLayout frontmatter={{ title, description, dateFormatted, image }}>
   <Content />
 </PostLayout>


### PR DESCRIPTION
## Summary
- pass `description` and `image` to `Layout`
- define optional `image` in content config
- inject Open Graph metadata in `<head>` using post frontmatter

## Testing
- `npm run check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bc1505ec8331b0e9c2dafb7c3877